### PR TITLE
Add basic metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Dockerfile
 *pyc
 similar_users/resources/*tsv
 similar_users/flask_config.yaml
+venv/

--- a/similar_users/flask_config_PLACEHOLDER.yaml
+++ b/similar_users/flask_config_PLACEHOLDER.yaml
@@ -7,7 +7,7 @@ ENABLE_UI: False
 
 EARLIEST_TS: 'YYYY-MM-DDTHH:MM:SSZ'
 MOST_RECENT_REV_TS: 'YYYY-MM-DDTHH:MM:SSZ'
-JSON_SORT_KEYS: False
+
 TEMPORAL_OFFSET: '<tuple of -k through k hour offset -- e.g., (-1, 0, 1)>'
 NAMESPACES: '<list of relevant namespace numbers -- e.g., [0] for just main namespace>'
 EDIT_WINDOW: 'maximum # of edits between two editors to be considered overlap'

--- a/similar_users/flask_config_PLACEHOLDER.yaml
+++ b/similar_users/flask_config_PLACEHOLDER.yaml
@@ -2,6 +2,7 @@
 CUSTOM_UA: "spd (cloud-vps) -- isaac@wikimedia.org"
 
 DEBUG: False
+LOG_LEVEL: WARNING
 
 ENABLE_UI: False
 

--- a/similar_users/wsgi.py
+++ b/similar_users/wsgi.py
@@ -103,6 +103,9 @@ def get_similar_users():
     }
     return jsonify(result)
 
+@app.route("/healthz", methods=["GET"])
+def healthz():
+    return "similarusers is running"
 
 def build_result(user_text, neighbor, num_pages_overlapped, num_similar, followup):
     """Build a single similar-user API response"""
@@ -176,6 +179,8 @@ def get_additional_edits(
             seconds=1
         )
     else:
+        # TODO move this timestamp out of configuration - either automate it
+        # based on current date or query it from a datastore.
         arvstart = app.config["MOST_RECENT_REV_TS"]
     if session is None:
         session = mwapi.Session(
@@ -266,6 +271,8 @@ def update_coedit_data(user_text, new_edits, k, lang="en", session=None, limit=2
             prop="revisions",
             pageids=pid,
             rvprop="ids|timestamp|user",
+            # TODO move this timestamp out of configuration - either automate it
+            # based on current date or query it from a datastore.
             rvstart=app.config["MOST_RECENT_REV_TS"],
             rvdir="newer",
             format="json",
@@ -357,6 +364,8 @@ def check_user_text(user_text):
         ucuser=user_text,
         ucprop="timestamp",
         ucnamespace="|".join([str(ns) for ns in app.config["NAMESPACES"]]),
+        # TODO move this timestamp out of configuration - either automate it
+        # based on current date or query it from a datastore.
         ucstart=app.config["EARLIEST_TS"],
         ucdir="newer",
         uclimit=1,

--- a/similar_users/wsgi.py
+++ b/similar_users/wsgi.py
@@ -12,10 +12,12 @@ import yaml
 from flask import Flask, request, jsonify, render_template, abort
 from flask_basicauth import BasicAuth
 from flask_cors import CORS
+from prometheus_flask_exporter import PrometheusMetrics
 from sklearn.metrics.pairwise import cosine_similarity
 
 app = Flask(__name__)
 
+metrics = PrometheusMetrics(app)
 basic_auth = BasicAuth(app)
 
 # Enable CORS for API endpoints
@@ -54,6 +56,8 @@ def index():
 
 @app.route("/similarusers", methods=["GET"])
 @basic_auth.required
+@metrics.counter('similar_users', 'Number of calls to similarusers',
+                 labels={'similar_count': lambda r: len(r.get_json()["results"])})
 def get_similar_users():
     """For a given user, find the k-most-similar users based on edit overlap.
 

--- a/similar_users/wsgi.py
+++ b/similar_users/wsgi.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timedelta
 from ast import literal_eval as make_tuple
 import argparse
+import distutils.util
 import logging
 import os
 import pathlib
@@ -68,28 +69,33 @@ def get_similar_users():
     """
     user_text, num_similar, followup, error = validate_api_args()
     if error is not None:
-        logging.error("Got error when trying to validate API arguments: %s", error)
+        app.logger.error("Got error when trying to validate API arguments: %s", error)
         return jsonify({"Error": error})
 
     edits = get_additional_edits(
         user_text, last_edit_timestamp=USER_METADATA[user_text]["most_recent_edit"]
     )
+    app.logger.debug("Got %d edits for user %s", len(edits) if edits else 0, user_text)
     if edits is not None:
         update_coedit_data(user_text, edits, app.config["EDIT_WINDOW"])
     overlapping_users = COEDIT_DATA.get(user_text, [])[:num_similar]
 
     oldest_edit = None
     last_edit = None
-    logging.info(str(USER_METADATA[user_text]))
+    app.logger.info(str(USER_METADATA[user_text]))
     if USER_METADATA[user_text]["oldest_edit"]:
         oldest_edit = datetime.strptime(
             USER_METADATA[user_text]["oldest_edit"], TIME_FORMAT
         ).strftime(READABLE_TIME_FORMAT)
+    else:
+        app.logger.debug("Didn't get an oldest_edit for user %s", user_text)
 
     if USER_METADATA[user_text]["most_recent_edit"]:
         last_edit = datetime.strptime(
             USER_METADATA[user_text]["most_recent_edit"], TIME_FORMAT
         ).strftime(READABLE_TIME_FORMAT)
+    else:
+        app.logger.debug("Didn't get an most_recent_edit for user %s", user_text)
 
     result = {
         "user_text": user_text,
@@ -101,6 +107,7 @@ def get_similar_users():
             for u in overlapping_users
         ],
     }
+    logging.debug("Got %d similarity results for user %s", len(result["results"]), user_text)
     return jsonify(result)
 
 @app.route("/healthz", methods=["GET"])
@@ -148,7 +155,7 @@ def get_temporal_overlap(u1, u2, k):
             [TEMPORAL_DATA.get(u2, {}).get("h", [0] * 24)],
         )[0][0]
     else:
-        logging.error(
+        app.logger.error(
             "Unrecognised temporal overlap key - expected 'd' or 'h' but got %s", k
         )
         raise Exception(
@@ -236,7 +243,7 @@ def get_additional_edits(
         USER_METADATA[user_text]["oldest_edit"] = min_timestamp
         return pageids
     except Exception as exc:
-        logging.error(
+        app.logger.error(
             "Failed to get additional edits for {user_text}, lang {lang}. {last_edit}. Exception: {exc}".format(
                 user_text=user_text,
                 lang=lang,
@@ -385,7 +392,7 @@ def check_user_text(user_text):
         )
         # this condition should never be met -- valid username w/ contributions but no account info
         if "missing" in result["query"]["users"][0]:
-            logging.error(
+            app.logger.error(
                 "Received request for user %s when they don't appear to have an enwiki account",
                 user_text,
             )
@@ -407,7 +414,7 @@ def check_user_text(user_text):
         elif "groups" in result["query"]["users"][0]:
             # bot
             if "bot" in result["query"]["users"][0]["groups"]:
-                logging.warning(
+                app.logger.warning(
                     "Received request for user %s which is a bot account - out of scope",
                     user_text,
                 )
@@ -425,13 +432,13 @@ def check_user_text(user_text):
                 }
                 TEMPORAL_DATA[user_text] = {"d": [0] * 7, "h": [0] * 24}
                 COEDIT_DATA[user_text] = []
-                logging.debug(
+                app.logger.debug(
                     "Received request for user %s but user is not in dataset", user_text
                 )
                 return None
 
     # account has no contributions in enwiki in namespaces
-    logging.warning(
+    app.logger.warning(
         "Received request for user %s but user does not have an account or edits in scope on enwiki",
         user_text,
     )
@@ -471,7 +478,7 @@ def validate_api_args():
 
 def load_coedit_data(resource_dir):
     """Load preprocessed data about edit overlap between users."""
-    logging.info("Loading co-edit data")
+    app.logger.info("Loading co-edit data")
     expected_header = ["user_text", "user_neighbor", "num_pages_overlapped"]
     with open(os.path.join(resource_dir, "coedit_counts.tsv"), "r") as fin:
         assert next(fin).strip().split("\t") == expected_header
@@ -488,7 +495,7 @@ def load_coedit_data(resource_dir):
 
 def load_temporal_data(resource_dir):
     """Load preprocessed temporal information about when an account has edited."""
-    logging.info("Loading temporal data")
+    app.logger.info("Loading temporal data")
     expected_header = ["user_text", "day_of_week", "hour_of_day", "num_edits"]
     with open(os.path.join(resource_dir, "temporal.tsv"), "r") as fin:
         assert next(fin).strip().split("\t") == expected_header
@@ -519,7 +526,7 @@ def update_temporal_data(user_text, day, hour, num_edits):
 
 def load_metadata(resource_dir):
     """Load some basic statistics about coverage of each account in the data."""
-    logging.info("Loading metadata")
+    app.logger.info("Loading metadata")
     expected_header = [
         "user_text",
         "is_anon",
@@ -535,7 +542,7 @@ def load_metadata(resource_dir):
             line = line_str.strip().split("\t")
             user = line[0]
             USER_METADATA[user] = {
-                "is_anon": bool(line[1]),
+                "is_anon": bool(distutils.util.strtobool(line[1])),
                 "num_edits": int(line[2]),
                 "num_pages": int(line[3]),
                 "most_recent_edit": line[4],
@@ -588,7 +595,10 @@ def main():
     args = parse_args()
     # TODO move app creation to its own function rather than using it as a
     # global
-    app.config.update(yaml.safe_load(open(args.config)))
+    config_yaml = yaml.safe_load(open(args.config))
+    app.config.update(config_yaml)
+
+    logging.basicConfig(level=logging.getLevelName(config_yaml["LOG_LEVEL"]))
 
     load_data(args.resourcedir)
     # Only use LISTEN_IP to configure docker port exposure - not for serving elsewhere.

--- a/similar_users/wsgi.py
+++ b/similar_users/wsgi.py
@@ -57,7 +57,7 @@ def index():
 @app.route("/similarusers", methods=["GET"])
 @basic_auth.required
 @metrics.counter('similar_users', 'Number of calls to similarusers',
-                 labels={'similar_count': lambda r: len(r.get_json()["results"])})
+                 labels={'similar_count': lambda r: len(r.get_json()["results"]) if "results" in r.get_json() else 0})
 def get_similar_users():
     """For a given user, find the k-most-similar users based on edit overlap.
 
@@ -407,7 +407,7 @@ def check_user_text(user_text):
         elif "groups" in result["query"]["users"][0]:
             # bot
             if "bot" in result["query"]["users"][0]["groups"]:
-                logging.warn(
+                logging.warning(
                     "Received request for user %s which is a bot account - out of scope",
                     user_text,
                 )
@@ -431,7 +431,7 @@ def check_user_text(user_text):
                 return None
 
     # account has no contributions in enwiki in namespaces
-    logging.warn(
+    logging.warning(
         "Received request for user %s but user does not have an account or edits in scope on enwiki",
         user_text,
     )


### PR DESCRIPTION
Add some basic Prometheus metrics. These metrics can be queried at `/metrics` - we get a bunch of useful metrics for free, and I have added a counter which will give us basic insight into the number of matches we are seeing per request to the service. 

Here's some sample metrics from the development docker container: 

```
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 339635.0
python_gc_objects_collected_total{generation="1"} 34255.0
python_gc_objects_collected_total{generation="2"} 808.0
# HELP python_gc_objects_uncollectable_total Uncollectable object found during GC
# TYPE python_gc_objects_uncollectable_total counter
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
# HELP python_gc_collections_total Number of times this generation was collected
# TYPE python_gc_collections_total counter
python_gc_collections_total{generation="0"} 634.0
python_gc_collections_total{generation="1"} 57.0
python_gc_collections_total{generation="2"} 2.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="7",patchlevel="3",version="3.7.3"} 1.0
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 8.57710592e+08
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 8.6491136e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.60632241239e+09
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 2.0300000000000002
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 6.0
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1.048576e+06
# HELP flask_exporter_info Information about the Prometheus Flask exporter
# TYPE flask_exporter_info gauge
flask_exporter_info{version="0.18.1"} 1.0
# HELP flask_http_request_duration_seconds Flask HTTP request duration in seconds
# TYPE flask_http_request_duration_seconds histogram
flask_http_request_duration_seconds_bucket{le="0.005",method="GET",path="/similarusers",status="200"} 0.0
flask_http_request_duration_seconds_bucket{le="0.01",method="GET",path="/similarusers",status="200"} 0.0
flask_http_request_duration_seconds_bucket{le="0.025",method="GET",path="/similarusers",status="200"} 0.0
flask_http_request_duration_seconds_bucket{le="0.05",method="GET",path="/similarusers",status="200"} 0.0
flask_http_request_duration_seconds_bucket{le="0.075",method="GET",path="/similarusers",status="200"} 0.0
flask_http_request_duration_seconds_bucket{le="0.1",method="GET",path="/similarusers",status="200"} 0.0
flask_http_request_duration_seconds_bucket{le="0.25",method="GET",path="/similarusers",status="200"} 0.0
flask_http_request_duration_seconds_bucket{le="0.5",method="GET",path="/similarusers",status="200"} 1.0
flask_http_request_duration_seconds_bucket{le="0.75",method="GET",path="/similarusers",status="200"} 2.0
flask_http_request_duration_seconds_bucket{le="1.0",method="GET",path="/similarusers",status="200"} 2.0
flask_http_request_duration_seconds_bucket{le="2.5",method="GET",path="/similarusers",status="200"} 2.0
flask_http_request_duration_seconds_bucket{le="5.0",method="GET",path="/similarusers",status="200"} 2.0
flask_http_request_duration_seconds_bucket{le="7.5",method="GET",path="/similarusers",status="200"} 2.0
flask_http_request_duration_seconds_bucket{le="10.0",method="GET",path="/similarusers",status="200"} 2.0
flask_http_request_duration_seconds_bucket{le="+Inf",method="GET",path="/similarusers",status="200"} 2.0
flask_http_request_duration_seconds_count{method="GET",path="/similarusers",status="200"} 2.0
flask_http_request_duration_seconds_sum{method="GET",path="/similarusers",status="200"} 1.1595558080002775
# HELP flask_http_request_duration_seconds_created Flask HTTP request duration in seconds
# TYPE flask_http_request_duration_seconds_created gauge
flask_http_request_duration_seconds_created{method="GET",path="/similarusers",status="200"} 1.6063224464266794e+09
# HELP flask_http_request_total Total number of HTTP requests
# TYPE flask_http_request_total counter
flask_http_request_total{method="GET",status="200"} 2.0
# HELP flask_http_request_created Total number of HTTP requests
# TYPE flask_http_request_created gauge
flask_http_request_created{method="GET",status="200"} 1.6063224464267576e+09
# HELP flask_http_request_exceptions_total Total number of HTTP requests which resulted in an exception
# TYPE flask_http_request_exceptions_total counter
# HELP similar_users_total Number of calls to similarusers
# TYPE similar_users_total counter
similar_users_total{similar_count="3"} 1.0
similar_users_total{similar_count="0"} 1.0
# HELP similar_users_created Number of calls to similarusers
# TYPE similar_users_created gauge
similar_users_created{similar_count="3"} 1.6063224464264638e+09
similar_users_created{similar_count="0"} 1.6063225965471826e+09
```

Under the `similar_users_total` counter we can see that there has been 1 call to the service where there have been 3 similar users, and 1 call where there has been 0 users. All other metrics we get for free. 